### PR TITLE
WIP: Bridging NIO to Combine with Network Transfer Subject

### DIFF
--- a/Sources/NIOCombine/NetworkTransferSubject+Cancellable.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject+Cancellable.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Combine
+import NIO
+
+///
+
+extension NetworkTransferSubject: Cancellable {
+    
+    ///
+    
+    public func cancel() {
+        writing.send(completion: .finished)
+    }
+    
+}

--- a/Sources/NIOCombine/NetworkTransferSubject+Publisher.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject+Publisher.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Combine
+import os
+
+///
+
+extension NetworkTransferSubject: Publisher {
+    
+    ///
+    
+    public func receive<S>(subscriber: S)
+    where S: Subscriber, Failure == S.Failure, Output == S.Input {
+        reading.receive(subscriber: subscriber)
+    }
+    
+}

--- a/Sources/NIOCombine/NetworkTransferSubject+Subject.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject+Subject.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Combine
+import OSLog
+
+///
+
+extension NetworkTransferSubject: Subject {
+    
+    ///
+    
+    public typealias Output = Data
+    
+    ///
+    
+    public func send(_ value: Data) {
+        guard !value.isEmpty else {
+            os_log(.debug, log: status, "dropping an empty packet!")
+            return
+        }
+
+        os_log(.debug, log: status, "sending a packet of %d bytes...", value.count)
+        writing.send(value)
+    }
+    
+    ///
+    
+    public func send(completion: Subscribers.Completion<Failure>) {
+        reading.send(completion: completion)
+    }
+    
+    ///
+    
+    public func send(subscription: Subscription) { // XXX: What does this do?
+        reading.send(subscription: subscription)
+    }
+
+}

--- a/Sources/NIOCombine/NetworkTransferSubject.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Combine
+import OSLog
+import NIO
+
+#if os(iOS) || os(macOS)
+import NIOTransportServices
+#endif
+
+///
+
+public class NetworkTransferSubject: ChannelInboundHandler {
+
+    ///
+    
+    public typealias InboundIn = ByteBuffer
+
+    ///
+    
+    public typealias OutboundOut = ByteBuffer
+
+    ///
+    
+    internal let reading = PassthroughSubject<Data, Failure>()
+    internal let writing = PassthroughSubject<Data, Failure>()
+    internal var closing = PassthroughSubject<Void, Never>()
+
+    ///
+    
+    internal var services: [Cancellable] = []
+
+    ///
+
+    internal var writes = DispatchQueue(label: "\(OSLog.thisSubsystem).writes",
+                                        qos: .background) // XXX: Consider concurrent!
+
+    ///
+
+    internal var status = OSLog.networkTransfer
+
+    ///
+
+    internal var pointsOfInterest = (
+        ConnectionActive: StaticString("ConnectionActive"),
+        PacketRead: StaticString("PacketRead")
+    )
+
+    ///
+
+    public func channelActive(context: ChannelHandlerContext) {
+        os_log(.debug, log: status, "establishing connection with %@...",
+               String(describing: context.remoteAddress))
+
+        let channel = context.channel
+
+        services.append(
+            writing
+            .receive(on: writes)
+            .assertNoFailure() // XXX: Impossible to fail!
+            .handleEvents(receiveCompletion: { _ in self.finish(context: context) })
+            .sink { self.writeAndFlush(packet: $0, to: channel) })
+
+        os_signpost(.begin, log: status, name: pointsOfInterest.ConnectionActive,
+                    "connected to %@", String(describing: context.remoteAddress))
+    }
+
+    ///
+
+    public func channelInactive(context: ChannelHandlerContext) {
+        os_log(.debug, log: status, "disconnected from %@", String(describing: context.remoteAddress))
+        cancel()
+    }
+
+    ///
+
+    public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        os_signpost(.begin, log: status, name: pointsOfInterest.PacketRead,
+                    "incoming data from %@", String(describing: context.remoteAddress))
+
+        var buffer = self.unwrapInboundIn(data)
+
+        guard
+            buffer.readableBytes > 0,
+            let packet = buffer.readBytes(length: buffer.readableBytes)
+        else {
+            errorCaught(context: context, error: Malfunction.packetCorrupted)
+            return
+        }
+
+        reading.send(Data(packet))
+
+        os_signpost(.end, log: status, name: pointsOfInterest.PacketRead, "packet accepted")
+        os_log(.debug, log: status, "received a packet of %d bytes", packet.count)
+    }
+
+    ///
+
+    internal func writeAndFlush(packet: Data, to channel: Channel) {
+        let payload = channel.allocator.buffer(bytes: packet)
+
+        _ = channel
+            .writeAndFlush(wrapOutboundOut(payload))
+            .map { [self] in
+                os_log(.debug, log: status, "delivered %d bytes", packet.count)
+            }
+            .recover { [self] in
+                os_log(.error, log: status, "write failed: %@", String(describing: $0))
+                send(completion: .failure(.connectionProblem(Malfunction.packetDeliveryFailed)))
+            }
+    }
+
+    ///
+
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
+        os_log(.error, log: status, "caught a connection problem: %@", String(describing: error))
+        send(completion: .failure(.connectionProblem(error)))
+    }
+
+
+    ///
+
+    private func finish(context: ChannelHandlerContext) {
+        writes.async(flags: .barrier) { [self] in
+            send(completion: .finished)
+            os_signpost(.end, log: status, name: pointsOfInterest.ConnectionActive, "finished")
+        }
+    }
+
+    ///
+
+    deinit {
+        services.forEach { $0.cancel() }
+    }
+
+}

--- a/Sources/NIOCombine/NetworkTransferSubject_Failure.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject_Failure.swift
@@ -1,0 +1,9 @@
+extension NetworkTransferSubject {
+
+    ///
+
+    public enum Failure: Error {
+        case connectionProblem(Error)
+    }
+
+}

--- a/Sources/NIOCombine/NetworkTransferSubject_Malfunction.swift
+++ b/Sources/NIOCombine/NetworkTransferSubject_Malfunction.swift
@@ -1,0 +1,10 @@
+extension NetworkTransferSubject {
+
+    ///
+
+    public enum Malfunction: Error, Equatable {
+        case packetCorrupted
+        case packetDeliveryFailed
+    }
+
+}

--- a/Sources/NIOCombine/OSLog_networkTransfer.swift
+++ b/Sources/NIOCombine/OSLog_networkTransfer.swift
@@ -1,0 +1,15 @@
+import OSLog
+
+///
+
+extension OSLog {
+
+    ///
+
+    internal static var thisSubsystem = "social.planetary.NIOCombine"
+
+    ///
+
+    static let networkTransfer = OSLog(subsystem: thisSubsystem, category: "NetworkTransferSubject")
+
+}

--- a/Tests/AllTests.xctestplan
+++ b/Tests/AllTests.xctestplan
@@ -1,0 +1,26 @@
+{
+  "configurations" : [
+    {
+      "id" : "9054C465-8DB0-4593-BB0A-90F7794EB6D3",
+      "name" : "Test Suite",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "nsZombieEnabled" : true,
+    "threadSanitizerEnabled" : true,
+    "undefinedBehaviorSanitizerEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "NIOCombineTests",
+        "name" : "NIOCombineTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/NIOCombineTests/Mocks/FailingChannelHandler.swift
+++ b/Tests/NIOCombineTests/Mocks/FailingChannelHandler.swift
@@ -1,0 +1,38 @@
+import Foundation
+import NIO
+
+///
+
+final class FailingChannelHandler: ChannelDuplexHandler {
+
+    ///
+
+    typealias InboundIn   = ByteBuffer
+    typealias InboundOut  = ByteBuffer
+    typealias OutboundIn  = ByteBuffer
+    typealias OutboundOut = ByteBuffer
+
+    ///
+
+    var caughtFailure: NSError?
+
+    ///
+
+    var failOnRead = false
+    var failOnSend = false // FIXME: Unused
+
+    ///
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        if let failure = caughtFailure {
+            return context.fireErrorCaught(failure)
+        }
+
+        if failOnRead {
+            return context.fireChannelRead(wrapOutboundOut(ByteBuffer()))
+        }
+
+        context.fireChannelRead(data)
+    }
+
+}

--- a/Tests/NIOCombineTests/NetworkTransferSubject_ConcurrenctAccessTests.swift
+++ b/Tests/NIOCombineTests/NetworkTransferSubject_ConcurrenctAccessTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Combine
+import NIO
+import XCTest
+
+@testable import NIOCombine
+
+final class NetworkTransferSubject_ConcurrentAccessTests: XCTestCase {
+
+    ///
+
+    func test_Sending_fromMultipleSimultaneousClients() throws {
+        throw XCTSkip("TODO: Make sure multiple clients can send at the same time without races.")
+    }
+
+    ///
+
+    func test_Receiving_byMultipleSimultaneousClients() throws {
+        throw XCTSkip("TODO: Make sure multiple clients can read witho race conditions.")
+    }
+
+}

--- a/Tests/NIOCombineTests/NetworkTransferSubject_PerformanceTests.swift
+++ b/Tests/NIOCombineTests/NetworkTransferSubject_PerformanceTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Combine
+import NIO
+import XCTest
+
+@testable import NIOCombine
+
+final class NetworkTransferSubject_PerformanceTests: XCTestCase {
+
+    ///
+
+    func test_Latency_ofWriting() throws {
+        throw XCTSkip("TODO: Reading speed should be predictable.")
+    }
+
+    ///
+
+    func test_Latency_ofReading() throws {
+        throw XCTSkip("TODO: Writing speed should be predictable as well.")
+    }
+
+    ///
+
+    func test_OverallThroughput_usingConstantPredictablePackets() throws {
+        throw XCTSkip("TODO: Overall transfer speed should be predictable in an organised environment.")
+    }
+
+    ///
+
+    func test_OverallThroughput_usingChaoticallySizedPackets() throws {
+        throw XCTSkip("TODO: Overall transfer speed should be predictable even among chaos.")
+    }
+
+}

--- a/Tests/NIOCombineTests/NetworkTransferSubject_TranportTests.swift
+++ b/Tests/NIOCombineTests/NetworkTransferSubject_TranportTests.swift
@@ -1,0 +1,262 @@
+import Foundation
+import Combine
+import NIO
+import XCTest
+
+//
+
+@testable import NIOCombine
+
+///
+
+final class NetworkTransferSubject_TransportTests: XCTestCase {
+
+    ///
+    
+    var events: EventLoopGroup? = nil
+
+    ///
+
+    var lock = DispatchSemaphore(value: 1)
+
+    ///
+
+    var serverSubject, clientSubject: NetworkTransferSubject?
+
+    ///
+
+    var server, client: Channel?
+
+    ///
+
+    var endpoint = try! SocketAddress(ipAddress: "0.0.0.0", port: arbitraryPort)
+
+    ///
+
+    static var arbitraryPort: Int { .random(in: 50000...51000) }
+
+    ///
+
+    var arbitraryPacketSizeBounds: ClosedRange<Int> = 2...1024
+
+    ///
+
+    var arbitraryPacket: Data {
+        Data((1...Int.random(in: arbitraryPacketSizeBounds)).map { _ in
+            return UInt8.random(in: UInt8.min...UInt8.max)
+        })
+    }
+
+    ///
+
+    var waitTime: TimeInterval = 5
+
+    ///
+
+    var failingChannelHandler: FailingChannelHandler?
+
+    ///
+
+    static func arbitrarySubject(for label: String) ->  NetworkTransferSubject { // FIXME: label, remove probably
+        return NetworkTransferSubject()
+    }
+
+    ///
+
+    override func setUpWithError() throws {
+        lock.wait()
+
+        events = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+
+        failingChannelHandler = FailingChannelHandler()
+
+        serverSubject = Self.arbitrarySubject(for: "server")
+        clientSubject = Self.arbitrarySubject(for: "client")
+
+        server = try setUp_NIOServer()
+        client = try setUp_NIOClient()
+    }
+
+    ///
+
+    func setUp_NIOServer() throws -> Channel {
+        try ServerBootstrap(group: events!)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { [self] channel in
+                return channel.pipeline.addHandler(serverSubject!)
+            }
+            .childChannelOption(ChannelOptions.recvAllocator, value: AdaptiveRecvByteBufferAllocator())
+            .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .bind(to: endpoint)
+            .wait()
+    }
+
+    ///
+
+    func setUp_NIOClient() throws -> Channel {
+        try ClientBootstrap(group: events!)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelInitializer { [self] channel in
+                channel.pipeline.addHandler(failingChannelHandler!).flatMap { _ in
+                    channel.pipeline.addHandler(clientSubject!)
+                }
+            }
+            .connect(to: endpoint)
+            .wait()
+    }
+    
+    ///
+    
+    override func tearDownWithError() throws {
+        defer { lock.signal() }
+
+        for channel in [client, server] { try channel?.close().wait() }
+        for subject in [clientSubject, serverSubject] { subject?.cancel() }
+
+        try events?.syncShutdownGracefully()
+        events = nil
+
+        serverSubject = nil
+        clientSubject = nil
+
+        failingChannelHandler = nil
+    }
+    
+    ///
+    
+    func test_Sending_networkPackets() {
+        let expectReceive = expectation(description: "expected to receive packet on the server side")
+        let packet = arbitraryPacket
+        let wait = serverSubject?.assertNoFailure().sink { receivedPacket in
+            XCTAssertEqual(receivedPacket, packet)
+            expectReceive.fulfill()
+        }
+
+        clientSubject?.send(packet)
+        clientSubject?.send(Data()) // NOTE: Empty packets should be dropped.
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+    
+    ///
+    
+    func test_Reading_networkPackets() {
+        let expectReceive = expectation(description: "expected to receive packet on the client side")
+        let packet = arbitraryPacket
+        let wait = clientSubject?.assertNoFailure().sink { receivedPacket in
+            XCTAssertEqual(receivedPacket, packet)
+            expectReceive.fulfill()
+        }
+
+        serverSubject?.send(packet)
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+    
+    ///
+    
+    func test_Cancellation_causedByLocalRequest() {
+        let expectedCompletion = expectation(description: "client must receive completion")
+
+        let wait =
+            clientSubject?
+            .handleEvents(receiveCompletion: { _ in expectedCompletion.fulfill() })
+            .assertNoFailure()
+            .sink { _ in }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [self] in
+            clientSubject?.cancel()
+        }
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+
+    ///
+
+    func test_Cancellation_causedByRemoteConnectionReset() {
+        let expectedCompletion = expectation(description: "server must receive completion")
+
+        let wait =
+            clientSubject?
+            .handleEvents(receiveCompletion: { _ in expectedCompletion.fulfill() })
+            .assertNoFailure()
+            .sink { _ in }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [self] in
+            client?.close().whenComplete { _ in
+                self.client = nil
+            }
+        }
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+
+    ///
+
+    func test_Failure_simulatingCaughtError() {
+        let expectedError = expectation(description: "client must fail")
+        failingChannelHandler!.caughtFailure = NSError(domain: "example.error", code: 191)
+
+        let wait =
+            clientSubject?
+            .catch { [self] error -> Empty<Data, Never> in
+                if case .connectionProblem(let failure) = error {
+                    XCTAssertEqual(failure as NSError, failingChannelHandler!.caughtFailure)
+                    expectedError.fulfill()
+                }
+
+                return .init()
+            }
+            .sink { _ in }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [self] in
+            serverSubject?.send(arbitraryPacket)
+        }
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+
+    ///
+
+    func test_Failure_simulatingReceiveProblem() {
+        let expectedError = expectation(description: "client must fail")
+        failingChannelHandler!.failOnRead = true
+
+        let wait =
+            clientSubject?
+            .catch { error -> Empty<Data, Never> in
+                print(error)
+                if case .connectionProblem(NetworkTransferSubject.Malfunction.packetCorrupted) = error {
+                    expectedError.fulfill()
+                }
+
+                return .init()
+            }
+            .sink { _ in }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [self] in
+            serverSubject?.send(arbitraryPacket)
+        }
+
+        waitForExpectations(timeout: waitTime) { _ in
+            wait?.cancel()
+        }
+    }
+
+    ///
+
+    func test_Failure_simulatingWriteAndFlushProblem() throws {
+        throw XCTSkip("It is not trivial to simulate broken writes...")
+    }
+
+}


### PR DESCRIPTION
Combine is a backbone of all the other libs, it allows them to play together in a timely and controllable fashion.
While using it across, one pattern became apparent and extremely annoying at that (especially to test).
That pattern is a `NetworkTransferSubject`: it behaves as a `PassthroughSubject` but inherits from `ChannelInboundHandler`, which allows it to interact with any Swift NIO bootstrap method, whether client or server, regardless the protocol choice.

### Current state

Testing annoyance remains, but now boxed in this one library.
All dependent libs now can skip a big portion of transport and transfer tests, and focus solely on the protocol requirements.

### TODO

- [ ] Move and adapt performance tests from peer discovery.
- [ ] Add more thorough concurrent access tests.
- [ ] Documentation.